### PR TITLE
adjust-renovate-schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "branchPrefix": "deps/",
   "timezone": "Europe/Berlin",
   "prConcurrentLimit": 20,
-  "schedule": ["before 6:00am"],
+  "schedule": ["every day"],
 
   "packageRules": [
     {


### PR DESCRIPTION
"before 6:00am" is unreliable because Renovate often runs after that time, skipping updates entirely.