### PR TITLE
fix: update Renovate schedule to valid cron syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "branchPrefix": "deps/",
   "timezone": "Europe/Berlin",
   "prConcurrentLimit": 20,
-  "schedule": ["0 6 * * *"],
+  "schedule": ["* 6 * * *"],
 
   "packageRules": [
     {


### PR DESCRIPTION
Replaced deprecated or invalid cron expression with compliant format (`* 6 * * *`)
to ensure compatibility with Renovate’s scheduling rules and prevent PR blockage.